### PR TITLE
PLAT-139-1 Add Netmask to Exp Engine

### DIFF
--- a/network.go
+++ b/network.go
@@ -1,0 +1,33 @@
+package exp
+
+import "net"
+
+// Matches
+
+type expContainsIp struct {
+	key, str string
+}
+
+func (e expContainsIp) Eval(p Params) bool {
+  _, cidrnet, err := net.ParseCIDR(p.Get(e.key))
+  if err != nil {
+		return false
+	}
+  testIp := net.ParseIP(e.str)
+  if err != nil {
+		return false
+	}
+
+	return cidrnet.Contains(testIp)
+}
+
+
+func (e expContainsIp) String() string {
+	return sprintf("[%s∋%s]", e.key, e.str)
+}
+
+// Contains is an expression that evaluates to true if substr is within the
+// value pointed to by key.
+func ContainsIp(key, substr string) Exp {
+	return expContainsIp{key, substr}
+}

--- a/network.go
+++ b/network.go
@@ -2,7 +2,7 @@ package exp
 
 import "net"
 
-// Matches
+// Conatins IP
 
 type expContainsIp struct {
 	key, str string
@@ -14,9 +14,7 @@ func (e expContainsIp) Eval(p Params) bool {
 		return false
 	}
   testIp := net.ParseIP(e.str)
-  if err != nil {
-		return false
-	}
+
 
 	return cidrnet.Contains(testIp)
 }
@@ -26,8 +24,13 @@ func (e expContainsIp) String() string {
 	return sprintf("[%s∋%s]", e.key, e.str)
 }
 
-// Contains is an expression that evaluates to true if substr is within the
-// value pointed to by key.
+// Contains is an expression that evaluates to true if substr falls within the cidr range
+// given example:
+//
+// 192.168.1.0/24 will match all IPs that fall between
+// 192.168.1.1 and 	192.168.1.254
+//
+// 192.168.1.0/32 will only match 192.168.1.0
 func ContainsIp(key, substr string) Exp {
 	return expContainsIp{key, substr}
 }

--- a/network_test.go
+++ b/network_test.go
@@ -1,0 +1,19 @@
+package exp
+
+import (
+    "testing"
+)
+
+var ipMap = Map{
+	"src_ip": "192.168.1.0/24",
+}
+
+func TestContainsIp(t *testing.T) {
+	for key, value := range map[string]string{
+		"src_ip": "192.168.1.61",
+	} {
+		if !ContainsIp(key, value).Eval(ipMap) {
+			t.Errorf("Match(%q, %q) should evaluate to true", key, value)
+		}
+	}
+}


### PR DESCRIPTION
Contains is an expression that evaluates to true if substr falls within the cidr range
given example:

192.168.1.0/24 will match all IPs that fall between
192.168.1.1 and     192.168.1.254

192.168.1.0/32 will only match 192.168.1.0
