### PR TITLE
PLAT-142: Test rule service throughput

### DIFF
--- a/network.go
+++ b/network.go
@@ -6,17 +6,14 @@ import "net"
 
 type expContainsIp struct {
 	key, str string
+	cidrnet *net.IPNet
 }
 
 func (e expContainsIp) Eval(p Params) bool {
-  _, cidrnet, err := net.ParseCIDR(p.Get(e.key))
-  if err != nil {
-		return false
-	}
-  testIp := net.ParseIP(e.str)
-
-
-	return cidrnet.Contains(testIp)
+	testIp := net.ParseIP(p.Get(e.key))
+	// net.ParseIP(p.Get(e.key))
+	// return false
+	return e.cidrnet.Contains(testIp)
 }
 
 
@@ -32,5 +29,71 @@ func (e expContainsIp) String() string {
 //
 // 192.168.1.0/32 will only match 192.168.1.0
 func ContainsIp(key, substr string) Exp {
-	return expContainsIp{key, substr}
+	_, cidrnet, err := net.ParseCIDR(substr)
+	if err != nil {
+		return nil
+	}
+	return expContainsIp{key, substr, cidrnet}
+}
+
+
+type expBitwiseContains struct {
+	key string
+	cidrnet *net.IPNet
+}
+
+// type IpParams interface {
+// 	Get(string) string
+// 	GetIp() net.IP
+// }
+
+type IpParams struct {
+	Ip []byte
+}
+
+func (p IpParams) Get(s string) string {
+	return s
+}
+
+func (e expBitwiseContains) Eval(p Params) bool {
+	// testIp := net.ParseIP(p.Get(e.key))
+	// return ((byte(e.cidrnet.IP) & byte(e.cidrnet.Mask)) == (byte(testIp.IP) & byte(e.cidrnet.Mask)))
+	//return true
+
+
+	// ip := IpParams(p)
+	// return e.cidrnet.Contains(ip.GetIp())
+
+	mask := e.cidrnet.Mask
+	ip := e.cidrnet.IP
+
+	switch p.(type) {
+	case IpParams:
+		testIp := p.(IpParams).Ip
+		for j := 0; j < 4; j++ {
+			if (ip[j]&mask[j] != testIp[j]&mask[j]) {
+				break
+			}
+			return true
+		}
+	}
+
+	// switch p.(type) {
+	// case IpParams:
+	// 	return e.cidrnet.Contains(p.(IpParams).Ip)
+	// }
+	return false
+}
+
+
+func (e expBitwiseContains) String() string {
+	return sprintf("[%s∋%s]", e.key, e.cidrnet)
+}
+
+func bitwiseContains(key, substr string) Exp {
+	_, cidrnet, err := net.ParseCIDR(substr)
+	if err != nil {
+		return nil
+	}
+	return expBitwiseContains{key, cidrnet}
 }

--- a/network.go
+++ b/network.go
@@ -3,7 +3,6 @@ package exp
 import "net"
 
 // Conatins IP
-
 type expContainsIp struct {
 	key, str string
 	cidrnet *net.IPNet
@@ -11,8 +10,6 @@ type expContainsIp struct {
 
 func (e expContainsIp) Eval(p Params) bool {
 	testIp := net.ParseIP(p.Get(e.key))
-	// net.ParseIP(p.Get(e.key))
-	// return false
 	return e.cidrnet.Contains(testIp)
 }
 
@@ -34,66 +31,4 @@ func ContainsIp(key, substr string) Exp {
 		return nil
 	}
 	return expContainsIp{key, substr, cidrnet}
-}
-
-
-type expBitwiseContains struct {
-	key string
-	cidrnet *net.IPNet
-}
-
-// type IpParams interface {
-// 	Get(string) string
-// 	GetIp() net.IP
-// }
-
-type IpParams struct {
-	Ip []byte
-}
-
-func (p IpParams) Get(s string) string {
-	return s
-}
-
-func (e expBitwiseContains) Eval(p Params) bool {
-	// testIp := net.ParseIP(p.Get(e.key))
-	// return ((byte(e.cidrnet.IP) & byte(e.cidrnet.Mask)) == (byte(testIp.IP) & byte(e.cidrnet.Mask)))
-	//return true
-
-
-	// ip := IpParams(p)
-	// return e.cidrnet.Contains(ip.GetIp())
-
-	mask := e.cidrnet.Mask
-	ip := e.cidrnet.IP
-
-	switch p.(type) {
-	case IpParams:
-		testIp := p.(IpParams).Ip
-		for j := 0; j < 4; j++ {
-			if (ip[j]&mask[j] != testIp[j]&mask[j]) {
-				break
-			}
-			return true
-		}
-	}
-
-	// switch p.(type) {
-	// case IpParams:
-	// 	return e.cidrnet.Contains(p.(IpParams).Ip)
-	// }
-	return false
-}
-
-
-func (e expBitwiseContains) String() string {
-	return sprintf("[%s∋%s]", e.key, e.cidrnet)
-}
-
-func bitwiseContains(key, substr string) Exp {
-	_, cidrnet, err := net.ParseCIDR(substr)
-	if err != nil {
-		return nil
-	}
-	return expBitwiseContains{key, cidrnet}
 }

--- a/network_test.go
+++ b/network_test.go
@@ -1,19 +1,198 @@
 package exp
 
 import (
+	"net"
     "testing"
+    "os"
+    _ "log"
+    "sync"
 )
 
+type Expression struct {
+	Id             int64
+	AnalyticType   string
+	ExpirationDate float64
+	Expression     Exp
+}
+
 var ipMap = Map{
-	"src_ip": "192.168.1.0/24",
+	"src_ip": "192.168.1.61",	
+}
+
+var RulesExp = make([]*Expression, 0, 1)
+var IpExp = make([]*Expression, 0, 1)
+
+var IpList = [][]byte{}
+var Ipinput = []IpParams{}
+var input = []Map{}
+
+var wgString sync.WaitGroup
+var wgByte sync.WaitGroup
+
+
+func dummyGet(s string) string{
+	return s
+}
+
+func TestMain(m *testing.M) {
+	id := 1
+	for i := 1; i < 100000; i++ {
+		nextRule := ContainsIp("src_ip", "10.10.10.0/24")
+		if nextRule == nil {
+			// log.Println("fail")
+		}
+		exObj := &Expression{
+			Expression: nextRule,
+			Id: int64(id),
+		}
+		RulesExp = append(RulesExp, exObj)
+
+	nextIp := bitwiseContains("src_ip", "10.10.10.0/24")
+	exObj = &Expression{
+		Expression: nextIp,
+		Id: int64(id),
+	}
+	IpExp = append(IpExp, exObj)
+
+		id++
+
+
+		ip1 := []byte{10,10,10,10}
+		IpList = append(IpList, ip1)
+	}
+
+	nextRule := ContainsIp("src_ip", "100.10.10.0/24")
+	exObj := &Expression{
+		Expression: nextRule,
+		Id: int64(id),
+	}
+	RulesExp = append(RulesExp, exObj)
+
+
+	nextIp := bitwiseContains("src_ip", "100.10.10.0/24")
+	exObj = &Expression{
+		Expression: nextIp,
+		Id: int64(id),
+	}
+	IpExp = append(IpExp, exObj)
+
+
+		ip2 := []byte{100,10,10,10}
+		IpList = append(IpList, ip2)
+
+	laps := 40000
+	for i := 0; i < laps; i++ {
+		input = append(input, map[string]string{
+			"src_ip": "100.10.10.10",
+		})
+		bIp := net.ParseIP("100.10.10.10")
+		Ipinput = append(Ipinput, IpParams{
+			Ip: bIp,
+		})
+	}
+
+	os.Exit(m.Run())
 }
 
 func TestContainsIp(t *testing.T) {
 	for key, value := range map[string]string{
-		"src_ip": "192.168.1.61",
+		"src_ip": "192.168.1.0/24",
 	} {
 		if !ContainsIp(key, value).Eval(ipMap) {
 			t.Errorf("Match(%q, %q) should evaluate to true", key, value)
+		}
+	}
+}
+
+func BenchmarkContainsIp_bit(b *testing.B) {
+	// laps := 40000
+	bits := [][]byte{}
+	// ip1 := []byte{10,10,10,10}
+	ip2 := []byte{100,10,10,10}
+	mask := []byte{255,255,255,0}
+
+	for i :=0; i<400; i++ {
+		bits = append(bits, ip2)
+	}
+		// bits = append(bits, ip2)
+	for _, r := range bits {
+		for _, ip := range IpList {
+			for j := 0; j < 4; j++ {
+				if (r[j]&mask[j] != ip[j]&mask[j]) {
+					 // log.Println("break")
+					break
+				}
+				if j == 3 {
+					 // log.Println("match", j, r, ip)
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkContainsIp_aaaparse(b *testing.B) {
+	// listNum := 99999
+
+	// input = append(input, &map[string]string{
+	// 		"SrcIp": "100.10.10.10",
+	// })
+
+	// log.Println("DEBUG len of rulesexp", len(RulesExp))
+	// log.Println("start")
+	for _, m := range input{
+		// for _, r := range RulesExp {
+		// 	if r.Expression.Eval(m) {
+		// 		// log.Println("Match", i)
+		// 		break
+		// 	}
+		// }
+		wgString.Add(1)
+		go evalString(m)
+	}
+	wgString.Wait()
+	// log.Println("end")
+}
+
+func BenchmarkContainsIp_aaafast(b *testing.B) {
+	// listNum := 99999
+
+	// input = append(input, &map[string]string{
+	// 		"SrcIp": "100.10.10.10",
+	// })
+
+	// log.Println("DEBUG len of rulesexp", len(RulesExp))
+	// log.Println("start")
+	for _, m := range Ipinput{
+		// for _, r := range IpExp {
+		// 	if r.Expression.Eval(m) {
+		// 		// log.Println("Match", i)
+		// 		break
+		// 	}
+		// }
+		wgByte.Add(1)
+		go evalByte(m)
+	}
+	wgByte.Wait()
+	// log.Println("end")
+}
+
+
+func evalString(m Map) {
+	defer wgString.Done()
+	for _, r := range RulesExp {
+		if r.Expression.Eval(m) {
+			// log.Println("Match", i)
+			break
+		}
+	}
+}
+
+func evalByte(m IpParams) {
+	defer wgByte.Done()
+	for _, r := range IpExp {
+		if r.Expression.Eval(m) {
+			// log.Println("Match", i)
+			break
 		}
 	}
 }

--- a/network_test.go
+++ b/network_test.go
@@ -1,10 +1,8 @@
 package exp
 
 import (
-	"net"
     "testing"
     "os"
-    _ "log"
     "sync"
 )
 
@@ -20,74 +18,30 @@ var ipMap = Map{
 }
 
 var RulesExp = make([]*Expression, 0, 1)
-var IpExp = make([]*Expression, 0, 1)
-
-var IpList = [][]byte{}
-var Ipinput = []IpParams{}
 var input = []Map{}
 
 var wgString sync.WaitGroup
-var wgByte sync.WaitGroup
-
-
-func dummyGet(s string) string{
-	return s
-}
+const ruleCnt = 100000
+const ipCount = 40000
 
 func TestMain(m *testing.M) {
-	id := 1
-	for i := 1; i < 100000; i++ {
+	for i := 1; i < ruleCnt; i++ {
 		nextRule := ContainsIp("src_ip", "10.10.10.0/24")
-		if nextRule == nil {
-			// log.Println("fail")
-		}
 		exObj := &Expression{
 			Expression: nextRule,
-			Id: int64(id),
 		}
 		RulesExp = append(RulesExp, exObj)
-
-	nextIp := bitwiseContains("src_ip", "10.10.10.0/24")
-	exObj = &Expression{
-		Expression: nextIp,
-		Id: int64(id),
-	}
-	IpExp = append(IpExp, exObj)
-
-		id++
-
-
-		ip1 := []byte{10,10,10,10}
-		IpList = append(IpList, ip1)
 	}
 
 	nextRule := ContainsIp("src_ip", "100.10.10.0/24")
 	exObj := &Expression{
 		Expression: nextRule,
-		Id: int64(id),
 	}
 	RulesExp = append(RulesExp, exObj)
 
-
-	nextIp := bitwiseContains("src_ip", "100.10.10.0/24")
-	exObj = &Expression{
-		Expression: nextIp,
-		Id: int64(id),
-	}
-	IpExp = append(IpExp, exObj)
-
-
-		ip2 := []byte{100,10,10,10}
-		IpList = append(IpList, ip2)
-
-	laps := 40000
-	for i := 0; i < laps; i++ {
+	for i := 0; i < ipCount; i++ {
 		input = append(input, map[string]string{
 			"src_ip": "100.10.10.10",
-		})
-		bIp := net.ParseIP("100.10.10.10")
-		Ipinput = append(Ipinput, IpParams{
-			Ip: bIp,
 		})
 	}
 
@@ -104,94 +58,21 @@ func TestContainsIp(t *testing.T) {
 	}
 }
 
-func BenchmarkContainsIp_bit(b *testing.B) {
-	// laps := 40000
-	bits := [][]byte{}
-	// ip1 := []byte{10,10,10,10}
-	ip2 := []byte{100,10,10,10}
-	mask := []byte{255,255,255,0}
-
-	for i :=0; i<400; i++ {
-		bits = append(bits, ip2)
+func BenchmarkContainsIp_100kIps(b *testing.B) {
+	m := map[string]string{
+		"src_ip": "100.10.10.10",
 	}
-		// bits = append(bits, ip2)
-	for _, r := range bits {
-		for _, ip := range IpList {
-			for j := 0; j < 4; j++ {
-				if (r[j]&mask[j] != ip[j]&mask[j]) {
-					 // log.Println("break")
-					break
-				}
-				if j == 3 {
-					 // log.Println("match", j, r, ip)
-				}
-			}
-		}
-	}
-}
-
-func BenchmarkContainsIp_aaaparse(b *testing.B) {
-	// listNum := 99999
-
-	// input = append(input, &map[string]string{
-	// 		"SrcIp": "100.10.10.10",
-	// })
-
-	// log.Println("DEBUG len of rulesexp", len(RulesExp))
-	// log.Println("start")
-	for _, m := range input{
-		// for _, r := range RulesExp {
-		// 	if r.Expression.Eval(m) {
-		// 		// log.Println("Match", i)
-		// 		break
-		// 	}
-		// }
+	for i := 0; i < ipCount; i++ {
 		wgString.Add(1)
 		go evalString(m)
 	}
 	wgString.Wait()
-	// log.Println("end")
 }
-
-func BenchmarkContainsIp_aaafast(b *testing.B) {
-	// listNum := 99999
-
-	// input = append(input, &map[string]string{
-	// 		"SrcIp": "100.10.10.10",
-	// })
-
-	// log.Println("DEBUG len of rulesexp", len(RulesExp))
-	// log.Println("start")
-	for _, m := range Ipinput{
-		// for _, r := range IpExp {
-		// 	if r.Expression.Eval(m) {
-		// 		// log.Println("Match", i)
-		// 		break
-		// 	}
-		// }
-		wgByte.Add(1)
-		go evalByte(m)
-	}
-	wgByte.Wait()
-	// log.Println("end")
-}
-
 
 func evalString(m Map) {
 	defer wgString.Done()
 	for _, r := range RulesExp {
 		if r.Expression.Eval(m) {
-			// log.Println("Match", i)
-			break
-		}
-	}
-}
-
-func evalByte(m IpParams) {
-	defer wgByte.Done()
-	for _, r := range IpExp {
-		if r.Expression.Eval(m) {
-			// log.Println("Match", i)
 			break
 		}
 	}


### PR DESCRIPTION
### PLAT-142: Test rule service throughput

Corrected ContainsIp to take a subnet for creation and evaluate against an ip addres. 
Change to exp ContainsIp parse CIDR on expression creation instead of on evaluation

Also added benchmark test for containsIp
to run just the benchmark test: `go test -run=XXX -bench .`
